### PR TITLE
Add basic navigation and styling

### DIFF
--- a/lib/login.dart
+++ b/lib/login.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'navigation.dart';
+import 'styles.dart';
+
+class LoginScreen extends StatelessWidget {
+  const LoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Login'),
+      ),
+      body: Padding(
+        padding: AppStyles.containerPadding,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('Login Screen', style: AppStyles.headerTextStyle),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pushNamed(context, AppRoutes.signup);
+              },
+              style: AppStyles.buttonStyle,
+              child: const Text('Go to Signup'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+import 'navigation.dart';
+import 'styles.dart';
+
 void main() {
   runApp(const MainApp());
 }
@@ -9,12 +12,10 @@ class MainApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: Scaffold(
-        body: Center(
-          child: Text('Hello World!'),
-        ),
-      ),
+    return MaterialApp(
+      theme: AppStyles.theme,
+      initialRoute: AppRoutes.login,
+      routes: AppRoutes.routes,
     );
   }
 }

--- a/lib/navigation.dart
+++ b/lib/navigation.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+import 'login.dart';
+import 'signup.dart';
+
+class AppRoutes {
+  static const String login = '/login';
+  static const String signup = '/signup';
+
+  static Map<String, WidgetBuilder> get routes => {
+        login: (context) => const LoginScreen(),
+        signup: (context) => const SignupScreen(),
+      };
+}

--- a/lib/signup.dart
+++ b/lib/signup.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'styles.dart';
+
+class SignupScreen extends StatelessWidget {
+  const SignupScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Signup'),
+      ),
+      body: Padding(
+        padding: AppStyles.containerPadding,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('Signup Screen', style: AppStyles.headerTextStyle),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pop(context);
+              },
+              style: AppStyles.buttonStyle,
+              child: const Text('Back to Login'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/styles.dart
+++ b/lib/styles.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class AppStyles {
+  static const Color primaryColor = Colors.deepOrange;
+
+  static const TextStyle headerTextStyle = TextStyle(
+    fontSize: 24,
+    fontWeight: FontWeight.bold,
+    color: primaryColor,
+  );
+
+  static final ButtonStyle buttonStyle = ElevatedButton.styleFrom(
+    backgroundColor: primaryColor,
+    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+  );
+
+  static const EdgeInsets containerPadding = EdgeInsets.all(16);
+
+  static final ThemeData theme = ThemeData(
+    primarySwatch: Colors.deepOrange,
+  );
+}


### PR DESCRIPTION
## Summary
- implement central styles for deep orange theme
- add login and signup screens
- create route configuration
- wire routes and theme into main app

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d063647e48331b28921516e372c25