### PR TITLE
Add login screen with validation

### DIFF
--- a/lib/login.dart
+++ b/lib/login.dart
@@ -99,17 +99,11 @@ class _LoginScreenState extends State<LoginScreen> {
               child: const Text('Login'),
             ),
             const SizedBox(height: 8),
-            GestureDetector(
-              onTap: () {
+            TextButton(
+              onPressed: () {
                 Navigator.pushNamed(context, AppRoutes.signup);
               },
-              child: Text(
-                'Don\'t have an account? Sign Up',
-                style: TextStyle(
-                  color: AppStyles.primaryColor,
-                  decoration: TextDecoration.underline,
-                ),
-              ),
+              child: const Text('Don\'t have an account? Sign Up'),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- implement a full login screen
- add text fields for email and password
- validate input and check credentials using `SharedPreferences`
- allow navigation to sign-up via clickable text

## Testing
- `flutter analyze` *(fails: `flutter` not found)*
- `dart analyze` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d0e5adce0833189fdfb5d9b58db4f