### PR TITLE
Add task detail view

### DIFF
--- a/lib/detail.dart
+++ b/lib/detail.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+import 'home.dart';
+import 'styles.dart';
+
+class DetailScreen extends StatelessWidget {
+  final Task task;
+  const DetailScreen({super.key, required this.task});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Task Details'),
+      ),
+      body: Padding(
+        padding: AppStyles.containerPadding,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(task.title, style: AppStyles.headerTextStyle),
+            const SizedBox(height: 8),
+            Text(task.description),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add task detail screen
- store task description when creating a task
- allow viewing details by tapping a task

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4847eeec83318be235adfd4fde9f