### PR TITLE
Store tasks as JSON with helper

### DIFF
--- a/lib/detail.dart
+++ b/lib/detail.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import 'home.dart';
+import 'models/task.dart';
 import 'styles.dart';
 
 class DetailScreen extends StatelessWidget {

--- a/lib/helpers/task_storage.dart
+++ b/lib/helpers/task_storage.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/task.dart';
+
+class TaskStorage {
+  static const String _tasksKey = 'tasks';
+
+  static Future<SharedPreferences> get _prefs async =>
+      SharedPreferences.getInstance();
+
+  static Future<List<Task>> getTasks() async {
+    final prefs = await _prefs;
+    final String? jsonString = prefs.getString(_tasksKey);
+    if (jsonString == null) return [];
+    final List<dynamic> jsonList = jsonDecode(jsonString) as List<dynamic>;
+    return jsonList
+        .map((e) => Task.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  static Future<void> saveTasks(List<Task> tasks) async {
+    final prefs = await _prefs;
+    final List<Map<String, dynamic>> jsonList =
+        tasks.map((t) => t.toJson()).toList();
+    final String jsonString = jsonEncode(jsonList);
+    await prefs.setString(_tasksKey, jsonString);
+  }
+}

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -3,13 +3,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'styles.dart';
 import 'detail.dart';
-
-class Task {
-  String title;
-  String description;
-  bool done;
-  Task(this.title, this.description, this.done);
-}
+import 'helpers/task_storage.dart';
+import 'models/task.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -31,26 +26,16 @@ class _HomeScreenState extends State<HomeScreen> {
 
   Future<void> _loadData() async {
     _prefs = await SharedPreferences.getInstance();
-    final List<String>? storedTasks = _prefs!.getStringList('tasks');
+    final List<Task> storedTasks = await TaskStorage.getTasks();
     final String? storedUsername = _prefs!.getString('username');
     setState(() {
       _username = storedUsername ?? '';
-      _tasks = storedTasks?.map((e) {
-            final parts = e.split('|');
-            return Task(
-              parts[0],
-              parts.length > 2 ? parts[1] : '',
-              parts.length > 2 ? parts[2] == '1' : parts.length > 1 && parts[1] == '1',
-            );
-          }).toList() ?? [];
+      _tasks = storedTasks;
     });
   }
 
   Future<void> _saveTasks() async {
-    final List<String> store = _tasks
-        .map((t) => '${t.title}|${t.description}|${t.done ? '1' : '0'}')
-        .toList();
-    await _prefs?.setStringList('tasks', store);
+    await TaskStorage.saveTasks(_tasks);
   }
 
   void _showAddDialog() {

--- a/lib/models/task.dart
+++ b/lib/models/task.dart
@@ -1,0 +1,18 @@
+class Task {
+  String title;
+  String description;
+  bool done;
+
+  Task(this.title, this.description, this.done);
+
+  Task.fromJson(Map<String, dynamic> json)
+      : title = json['title'] as String,
+        description = json['description'] as String? ?? '',
+        done = json['done'] as bool? ?? false;
+
+  Map<String, dynamic> toJson() => {
+        'title': title,
+        'description': description,
+        'done': done,
+      };
+}


### PR DESCRIPTION
## Summary
- manage tasks using JSON-based persistence
- add a Task model class
- create TaskStorage helper for saving/loading tasks
- update HomeScreen and DetailScreen to use the new model

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4fbbcd188331aa0971e6c824aed4