### PR TITLE
Add countries feature

### DIFF
--- a/lib/countries_screen.dart
+++ b/lib/countries_screen.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import 'helpers/country_service.dart';
+import 'models/country.dart';
+
+class CountriesScreen extends StatefulWidget {
+  const CountriesScreen({super.key});
+
+  @override
+  State<CountriesScreen> createState() => _CountriesScreenState();
+}
+
+class _CountriesScreenState extends State<CountriesScreen> {
+  late Future<List<Country>> _countriesFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _countriesFuture = CountryService.fetchCountries();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Countries')),
+      body: FutureBuilder<List<Country>>(
+        future: _countriesFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(child: Text('No countries found'));
+          } else {
+            final countries = snapshot.data!;
+            return ListView.builder(
+              itemCount: countries.length,
+              itemBuilder: (context, index) {
+                return ListTile(
+                  title: Text(countries[index].name),
+                );
+              },
+            );
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/helpers/country_service.dart
+++ b/lib/helpers/country_service.dart
@@ -6,7 +6,7 @@ import '../models/country.dart';
 
 class CountryService {
   static Future<List<Country>> fetchCountries() async {
-    final uri = Uri.parse('https://restcountries.com/v3.1/all');
+    final uri = Uri.parse('https://restcountries.com/v3.1/all?fields=name');
     final response = await http.get(uri);
     if (response.statusCode == 200) {
       final List<dynamic> jsonList = jsonDecode(response.body) as List<dynamic>;

--- a/lib/helpers/country_service.dart
+++ b/lib/helpers/country_service.dart
@@ -1,0 +1,21 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../models/country.dart';
+
+class CountryService {
+  static Future<List<Country>> fetchCountries() async {
+    final uri = Uri.parse('https://restcountries.com/v3.1/all');
+    final response = await http.get(uri);
+    if (response.statusCode == 200) {
+      final List<dynamic> jsonList = jsonDecode(response.body) as List<dynamic>;
+      final countries =
+          jsonList.map((e) => Country.fromJson(e as Map<String, dynamic>)).toList();
+      countries.sort((a, b) => a.name.compareTo(b.name));
+      return countries;
+    } else {
+      throw Exception('Failed to load countries');
+    }
+  }
+}

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -5,6 +5,7 @@ import 'styles.dart';
 import 'detail.dart';
 import 'helpers/task_storage.dart';
 import 'models/task.dart';
+import 'navigation.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -109,6 +110,12 @@ class _HomeScreenState extends State<HomeScreen> {
           IconButton(
             icon: const Icon(Icons.settings),
             onPressed: () {},
+          ),
+          IconButton(
+            icon: const Icon(Icons.public),
+            onPressed: () {
+              Navigator.pushNamed(context, AppRoutes.countries);
+            },
           ),
         ],
       ),

--- a/lib/models/country.dart
+++ b/lib/models/country.dart
@@ -1,0 +1,16 @@
+class Country {
+  final String name;
+
+  Country({required this.name});
+
+  factory Country.fromJson(Map<String, dynamic> json) {
+    final dynamic nameData = json['name'];
+    if (nameData is Map<String, dynamic>) {
+      final String? common = nameData['common'] as String?;
+      if (common != null) {
+        return Country(name: common);
+      }
+    }
+    return Country(name: 'Unknown');
+  }
+}

--- a/lib/navigation.dart
+++ b/lib/navigation.dart
@@ -3,15 +3,18 @@ import 'package:flutter/material.dart';
 import 'login.dart';
 import 'signup.dart';
 import 'home.dart';
+import 'countries_screen.dart';
 
 class AppRoutes {
   static const String login = '/login';
   static const String signup = '/signup';
   static const String home = '/home';
+  static const String countries = '/countries';
 
   static Map<String, WidgetBuilder> get routes => {
         login: (context) => const LoginScreen(),
         signup: (context) => const SignupScreen(),
         home: (context) => const HomeScreen(),
+        countries: (context) => const CountriesScreen(),
       };
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -88,6 +88,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.13.6"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -301,6 +317,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences: ^2.2.2
+  http: ^0.13.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add Country model
- add service to fetch countries from API
- add CountriesScreen with FutureBuilder
- add route for countries
- link screen via button on home page
- include `http` package

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e56d158fc83318cd9662638f89aad