### PR TITLE
Add drawer-based settings

### DIFF
--- a/lib/edit_user_info_screen.dart
+++ b/lib/edit_user_info_screen.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'styles.dart';
+
+class EditUserInfoScreen extends StatefulWidget {
+  const EditUserInfoScreen({super.key});
+
+  @override
+  State<EditUserInfoScreen> createState() => _EditUserInfoScreenState();
+}
+
+class _EditUserInfoScreenState extends State<EditUserInfoScreen> {
+  final TextEditingController _usernameController = TextEditingController();
+  final TextEditingController _emailController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _loadUserInfo();
+  }
+
+  Future<void> _loadUserInfo() async {
+    final prefs = await SharedPreferences.getInstance();
+    _usernameController.text = prefs.getString('username') ?? '';
+    _emailController.text = prefs.getString('email') ?? '';
+  }
+
+  Future<void> _saveUserInfo() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('username', _usernameController.text.trim());
+    await prefs.setString('email', _emailController.text.trim());
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('User info updated')),
+    );
+    Navigator.pop(context);
+  }
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edit User Info')),
+      body: Padding(
+        padding: AppStyles.containerPadding,
+        child: Column(
+          children: [
+            TextField(
+              controller: _usernameController,
+              decoration: const InputDecoration(labelText: 'Username'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _saveUserInfo,
+              style: AppStyles.buttonStyle,
+              child: const Text('Save'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -17,6 +17,7 @@ class HomeScreen extends StatefulWidget {
 class _HomeScreenState extends State<HomeScreen> {
   List<Task> _tasks = [];
   String _username = '';
+  String _email = '';
   SharedPreferences? _prefs;
 
   @override
@@ -29,8 +30,10 @@ class _HomeScreenState extends State<HomeScreen> {
     _prefs = await SharedPreferences.getInstance();
     final List<Task> storedTasks = await TaskStorage.getTasks();
     final String? storedUsername = _prefs!.getString('username');
+    final String? storedEmail = _prefs!.getString('email');
     setState(() {
       _username = storedUsername ?? '';
+      _email = storedEmail ?? '';
       _tasks = storedTasks;
     });
   }
@@ -95,6 +98,17 @@ class _HomeScreenState extends State<HomeScreen> {
     _saveTasks();
   }
 
+  Future<void> _logout() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+    if (!mounted) return;
+    Navigator.pushNamedAndRemoveUntil(
+      context,
+      AppRoutes.login,
+      (route) => false,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final List<Task> toDo = _tasks.where((t) => !t.done).toList();
@@ -102,15 +116,7 @@ class _HomeScreenState extends State<HomeScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('To Do'),
-        leading: IconButton(
-          icon: const Icon(Icons.menu),
-          onPressed: () {},
-        ),
         actions: [
-          IconButton(
-            icon: const Icon(Icons.settings),
-            onPressed: () {},
-          ),
           IconButton(
             icon: const Icon(Icons.public),
             onPressed: () {
@@ -118,6 +124,65 @@ class _HomeScreenState extends State<HomeScreen> {
             },
           ),
         ],
+      ),
+      drawer: Drawer(
+        child: ListView(
+          children: [
+            UserAccountsDrawerHeader(
+              accountName: Text(_username),
+              accountEmail: Text(_email),
+              currentAccountPicture: const CircleAvatar(
+                child: Icon(Icons.person),
+              ),
+            ),
+            ListTile(
+              leading: const Icon(Icons.person),
+              title: const Text('User Information'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.pushNamed(context, AppRoutes.editUserInfo);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.settings),
+              title: const Text('Account Settings'),
+              onTap: () {
+                Navigator.pop(context);
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Account settings not implemented')),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.notifications),
+              title: const Text('Notifications'),
+              onTap: () {
+                Navigator.pop(context);
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Notifications not implemented')),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.info),
+              title: const Text('About'),
+              onTap: () {
+                Navigator.pop(context);
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Habit Tracker App')),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.logout),
+              title: const Text('Logout'),
+              onTap: () {
+                Navigator.pop(context);
+                _logout();
+              },
+            ),
+          ],
+        ),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: _showAddDialog,

--- a/lib/navigation.dart
+++ b/lib/navigation.dart
@@ -4,17 +4,20 @@ import 'login.dart';
 import 'signup.dart';
 import 'home.dart';
 import 'countries_screen.dart';
+import 'edit_user_info_screen.dart';
 
 class AppRoutes {
   static const String login = '/login';
   static const String signup = '/signup';
   static const String home = '/home';
   static const String countries = '/countries';
+  static const String editUserInfo = '/editUserInfo';
 
   static Map<String, WidgetBuilder> get routes => {
         login: (context) => const LoginScreen(),
         signup: (context) => const SignupScreen(),
         home: (context) => const HomeScreen(),
         countries: (context) => const CountriesScreen(),
+        editUserInfo: (context) => const EditUserInfoScreen(),
       };
 }


### PR DESCRIPTION
## Summary
- move settings to drawer on home screen
- add EditUserInfoScreen for editing profile
- wire new screen through navigation and remove old Settings screen

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e67989a3c8331ba70d38f3d6f28c5