### PR TITLE
Implement settings screen

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -148,9 +148,7 @@ class _HomeScreenState extends State<HomeScreen> {
               title: const Text('Account Settings'),
               onTap: () {
                 Navigator.pop(context);
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Account settings not implemented')),
-                );
+                Navigator.pushNamed(context, AppRoutes.settings);
               },
             ),
             ListTile(

--- a/lib/navigation.dart
+++ b/lib/navigation.dart
@@ -5,6 +5,7 @@ import 'signup.dart';
 import 'home.dart';
 import 'countries_screen.dart';
 import 'edit_user_info_screen.dart';
+import 'settings_screen.dart';
 
 class AppRoutes {
   static const String login = '/login';
@@ -12,6 +13,7 @@ class AppRoutes {
   static const String home = '/home';
   static const String countries = '/countries';
   static const String editUserInfo = '/editUserInfo';
+  static const String settings = '/settings';
 
   static Map<String, WidgetBuilder> get routes => {
         login: (context) => const LoginScreen(),
@@ -19,5 +21,6 @@ class AppRoutes {
         home: (context) => const HomeScreen(),
         countries: (context) => const CountriesScreen(),
         editUserInfo: (context) => const EditUserInfoScreen(),
+        settings: (context) => const SettingsScreen(),
       };
 }

--- a/lib/settings_screen.dart
+++ b/lib/settings_screen.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'styles.dart';
+
+class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _usernameController = TextEditingController();
+  final TextEditingController _ageController = TextEditingController();
+  final TextEditingController _countryController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _loadProfile();
+  }
+
+  Future<void> _loadProfile() async {
+    final prefs = await SharedPreferences.getInstance();
+    _nameController.text = prefs.getString('name') ?? '';
+    _usernameController.text = prefs.getString('username') ?? '';
+    final int? age = prefs.getInt('age');
+    _ageController.text = age != null && age > 0 ? age.toString() : '';
+    _countryController.text = prefs.getString('country') ?? '';
+  }
+
+  Future<void> _saveProfile() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('name', _nameController.text.trim());
+    await prefs.setString('username', _usernameController.text.trim());
+    final int? age = int.tryParse(_ageController.text);
+    if (age != null) {
+      await prefs.setInt('age', age);
+    }
+    await prefs.setString('country', _countryController.text.trim());
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Profile updated')),
+    );
+    Navigator.pop(context);
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _usernameController.dispose();
+    _ageController.dispose();
+    _countryController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: SingleChildScrollView(
+        padding: AppStyles.containerPadding,
+        child: Column(
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _usernameController,
+              decoration: const InputDecoration(labelText: 'Username'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _ageController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: 'Age'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _countryController,
+              decoration: const InputDecoration(labelText: 'Country'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _saveProfile,
+              style: AppStyles.buttonStyle,
+              child: const Text('Save'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated SettingsScreen that saves name, username, age and country
- add `/settings` route
- hook up the drawer's *Account Settings* item to open the new page

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6d1e46b08331bd203ba13c07f100